### PR TITLE
Constants and template literal resolution

### DIFF
--- a/transforms/convert-object-selectors-in-tests/README.md
+++ b/transforms/convert-object-selectors-in-tests/README.md
@@ -33,6 +33,7 @@ ember-test-convert-object-selectors-codemod convert-object-selectors-in-tests pa
 ```js
 import { module, test } from 'qunit';
 import { render, find, click, fillIn } from '@ember/test-helpers';
+import { IMPORTED_CONSTS } from 'fake-location';
 
 module('foo', function() {
 
@@ -40,6 +41,8 @@ module('foo', function() {
     block: '[data-test-block]',
     image: '[data-test-image]',
   };
+
+  const constantSelector = '[data-test-a-cool-selector]';
 
   const NESTED_SELECTORS = {
     WITH: {
@@ -89,6 +92,27 @@ module('foo', function() {
 
     assert.dom(SELECTORS.image).exists();
   });
+
+  test('constant selector test', async function(assert) {
+    assert.expect(1);
+
+    assert.notOk(find(constantSelector));
+  });
+
+  test('constant within template literal test', async function(assert) {
+    assert.expect(1);
+
+    assert.dom(`${constantSelector} [data-test-nested]`).exists();
+    assert.ok(find(`${NESTED_SELECTORS.WITH.BUTTON} [data-test-nested]`));
+    assert.ok(find(`[data-test-nested] ${NESTED_SELECTORS.WITH.BUTTON}`));
+    assert.ok(find(`[data-test-nested] ${NESTED_SELECTORS.WITH.BUTTON} [data-test-nested] ${constantSelector}`));
+  });
+
+  test('unresolveable template literal test', async function(assert) {
+    assert.expect(1);
+
+    assert.dom(`${IMPORTED_CONSTS.module} [data-test-nested]`).exists();
+  });
 });
 
 ```
@@ -97,6 +121,7 @@ module('foo', function() {
 ```js
 import { module, test } from 'qunit';
 import { render, find, click, fillIn } from '@ember/test-helpers';
+import { IMPORTED_CONSTS } from 'fake-location';
 
 module('foo', function() {
 
@@ -104,6 +129,8 @@ module('foo', function() {
     block: '[data-test-block]',
     image: '[data-test-image]',
   };
+
+  const constantSelector = '[data-test-a-cool-selector]';
 
   const NESTED_SELECTORS = {
     WITH: {
@@ -152,6 +179,27 @@ module('foo', function() {
     await fillIn('[data-test-block]', 'foo');
 
     assert.dom('[data-test-image]').exists();
+  });
+
+  test('constant selector test', async function(assert) {
+    assert.expect(1);
+
+    assert.notOk(find('[data-test-a-cool-selector]'));
+  });
+
+  test('constant within template literal test', async function(assert) {
+    assert.expect(1);
+
+    assert.dom('[data-test-a-cool-selector] [data-test-nested]').exists();
+    assert.ok(find('[data-test-button] [data-test-nested]'));
+    assert.ok(find('[data-test-nested] [data-test-button]'));
+    assert.ok(find('[data-test-nested] [data-test-button] [data-test-nested] [data-test-a-cool-selector]'));
+  });
+
+  test('unresolveable template literal test', async function(assert) {
+    assert.expect(1);
+
+    assert.dom(`${IMPORTED_CONSTS.module} [data-test-nested]`).exists();
   });
 });
 

--- a/transforms/convert-object-selectors-in-tests/README.md
+++ b/transforms/convert-object-selectors-in-tests/README.md
@@ -16,7 +16,7 @@ ember-test-convert-object-selectors-codemod convert-object-selectors-in-tests pa
 ## Limitations
 
 * Does not transform imported object selectors, e.g. `import SELECTORS from 'test-helpers/test-selectors'`
-* Does not transform simple variables, e.g. `assert.dom(myTestSelector)`
+* Does not transform objects defined on this context, e.g. `assert.dom(this.SELECTOR.IMAGE)`
 * Does not remove unused object definitions after transform
 
 ## Input / Output

--- a/transforms/convert-object-selectors-in-tests/__testfixtures__/convert-object-selectors.input.js
+++ b/transforms/convert-object-selectors-in-tests/__testfixtures__/convert-object-selectors.input.js
@@ -8,6 +8,8 @@ module('foo', function() {
     image: '[data-test-image]',
   };
 
+  const constantSelector = '[data-test-a-cool-selector]';
+
   const NESTED_SELECTORS = {
     WITH: {
       CONTAINER: '[data-test-container]',
@@ -55,5 +57,11 @@ module('foo', function() {
     await fillIn(SELECTORS.block, 'foo');
 
     assert.dom(SELECTORS.image).exists();
+  });
+
+  test('constant selector test', async function(assert) {
+    assert.expect(1);
+
+    assert.notOk(find(constantSelector));
   });
 });

--- a/transforms/convert-object-selectors-in-tests/__testfixtures__/convert-object-selectors.input.js
+++ b/transforms/convert-object-selectors-in-tests/__testfixtures__/convert-object-selectors.input.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { render, find, click, fillIn } from '@ember/test-helpers';
+import { IMPORTED_CONSTS } from 'fake-location';
 
 module('foo', function() {
 
@@ -63,5 +64,20 @@ module('foo', function() {
     assert.expect(1);
 
     assert.notOk(find(constantSelector));
+  });
+
+  test('constant within template literal test', async function(assert) {
+    assert.expect(1);
+
+    assert.dom(`${constantSelector} [data-test-nested]`).exists();
+    assert.ok(find(`${NESTED_SELECTORS.WITH.BUTTON} [data-test-nested]`));
+    assert.ok(find(`[data-test-nested] ${NESTED_SELECTORS.WITH.BUTTON}`));
+    assert.ok(find(`[data-test-nested] ${NESTED_SELECTORS.WITH.BUTTON} [data-test-nested] ${constantSelector}`));
+  });
+
+  test('unresolveable template literal test', async function(assert) {
+    assert.expect(1);
+
+    assert.dom(`${IMPORTED_CONSTS.module} [data-test-nested]`).exists();
   });
 });

--- a/transforms/convert-object-selectors-in-tests/__testfixtures__/convert-object-selectors.output.js
+++ b/transforms/convert-object-selectors-in-tests/__testfixtures__/convert-object-selectors.output.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { render, find, click, fillIn } from '@ember/test-helpers';
+import { IMPORTED_CONSTS } from 'fake-location';
 
 module('foo', function() {
 
@@ -63,5 +64,20 @@ module('foo', function() {
     assert.expect(1);
 
     assert.notOk(find('[data-test-a-cool-selector]'));
+  });
+
+  test('constant within template literal test', async function(assert) {
+    assert.expect(1);
+
+    assert.dom('[data-test-a-cool-selector] [data-test-nested]').exists();
+    assert.ok(find('[data-test-button] [data-test-nested]'));
+    assert.ok(find('[data-test-nested] [data-test-button]'));
+    assert.ok(find('[data-test-nested] [data-test-button] [data-test-nested] [data-test-a-cool-selector]'));
+  });
+
+  test('unresolveable template literal test', async function(assert) {
+    assert.expect(1);
+
+    assert.dom(`${IMPORTED_CONSTS.module} [data-test-nested]`).exists();
   });
 });

--- a/transforms/convert-object-selectors-in-tests/__testfixtures__/convert-object-selectors.output.js
+++ b/transforms/convert-object-selectors-in-tests/__testfixtures__/convert-object-selectors.output.js
@@ -8,6 +8,8 @@ module('foo', function() {
     image: '[data-test-image]',
   };
 
+  const constantSelector = '[data-test-a-cool-selector]';
+
   const NESTED_SELECTORS = {
     WITH: {
       CONTAINER: '[data-test-container]',
@@ -55,5 +57,11 @@ module('foo', function() {
     await fillIn('[data-test-block]', 'foo');
 
     assert.dom('[data-test-image]').exists();
+  });
+
+  test('constant selector test', async function(assert) {
+    assert.expect(1);
+
+    assert.notOk(find('[data-test-a-cool-selector]'));
   });
 });

--- a/transforms/convert-object-selectors-in-tests/index.js
+++ b/transforms/convert-object-selectors-in-tests/index.js
@@ -1,5 +1,4 @@
 const { getParser } = require('codemod-cli').jscodeshift;
-const { getOptions } = require('codemod-cli');
 
 module.exports = function transformer(file, api) {
   const j = getParser(api);
@@ -18,45 +17,54 @@ module.exports = function transformer(file, api) {
 
   root
     .find(j.CallExpression, hasAssertDomOrTestHelper)
-    .filter(p => p.value.arguments.find(arg => arg.type === "MemberExpression"))
-    .forEach(p => {
-      // for each object selector, try to find its associated definition and the string value,
-      // e.g. if we have assert.dom(SELECTORS.NAME), look for const SELECTORS = { NAME: '[data-test-foo]' } }
-      const result = p.value.arguments[0];
-      if (!result.object) {
-        return;
-      }
-      // this should be the name for the object selector, e.g. 'SELECTORS'
-      const objectIdentifierName =
-        result.object.name || (result.object.object && result.object.object.name);
-      // this should be the object property key, e.g. 'NAME'
-      const keyName = result.property && result.property.name;
+    .filter((p) => {
+      return p.value.arguments.find((arg) => arg.type !== 'Literal');
+    })
+    .forEach((p) => {
+      if (p.value.arguments[0].type === 'Identifier') {
+        const constName = p.value.arguments[0].name;
+        const variableDefinition = root.find(j.VariableDeclarator, {
+          type: 'VariableDeclarator',
+          id: { type: 'Identifier', name: constName },
+        });
+        const varValue = variableDefinition.get(0).node.init.value;
+        p.value.arguments[0] = j.stringLiteral(varValue);
+      } else if (p.value.arguments[0].type === 'MemberExpression') {
+        // for each object selector, try to find its associated definition and the string value,
+        // e.g. if we have assert.dom(SELECTORS.NAME), look for const SELECTORS = { NAME: '[data-test-foo]' } }
+        const result = p.value.arguments[0];
+        if (!result.object) {
+          return;
+        }
 
-      let objectExpressions = root
-        .findVariableDeclarators(objectIdentifierName)
-        .find(j.ObjectExpression);
+        // this should be the name for the object selector, e.g. 'SELECTORS'
+        const objectIdentifierName =
+          result.object.name || (result.object.object && result.object.object.name);
+        // this should be the object property key, e.g. 'NAME'
+        const keyName = result.property && result.property.name;
 
-      // go one level deeper if the node we're currently looking at is still a MemberExpression
-      // this accounts for something like SELECTORS.AT.NAME
-      if (result.object.type === 'MemberExpression') {
-        objectExpressions = objectExpressions.find(j.ObjectExpression);
-      }
-
-      const keyPaths = objectExpressions.find(j.ObjectProperty, {
-        key: {
-          name: keyName,
-        },
-      });
-
-      if (keyPaths.length) {
-        const { node } = keyPaths.get(0);
-        const value = node.value && node.value.value;
-        if (value) {
-          p.value.arguments[0] = j.stringLiteral(value);
+        let objectExpressions = root
+          .findVariableDeclarators(objectIdentifierName)
+          .find(j.ObjectExpression);
+        // go one level deeper if the node we're currently looking at is still a MemberExpression
+        // this accounts for something like SELECTORS.AT.NAME
+        if (result.object.type === 'MemberExpression') {
+          objectExpressions = objectExpressions.find(j.ObjectExpression);
+        }
+        const keyPaths = objectExpressions.find(j.ObjectProperty, {
+          key: {
+            name: keyName,
+          },
+        });
+        if (keyPaths.length) {
+          const { node } = keyPaths.get(0);
+          const value = node.value && node.value.value;
+          if (value) {
+            p.value.arguments[0] = j.stringLiteral(value);
+          }
         }
       }
-    }
-  );
+    });
 
   return root.toSource({ quote: 'single' });
-}
+};

--- a/transforms/convert-object-selectors-in-tests/index.js
+++ b/transforms/convert-object-selectors-in-tests/index.js
@@ -15,53 +15,88 @@ module.exports = function transformer(file, api) {
     return hasAssertDom || emberTestHelpers.includes(callee.name);
   }
 
+  /**
+   * Given a node resolve it's selector value.
+   * @param {Node} argument the argument node (e.g in find(selector.pickle), selector.pickle is the node)
+   * @return {String} the resolved selector
+   */
+  function resolveArgument(argument) {
+    if (argument.type === 'Identifier') {
+      const constName = argument.name;
+      const variableDefinition = root.find(j.VariableDeclarator, {
+        type: 'VariableDeclarator',
+        id: { type: 'Identifier', name: constName },
+      });
+      const varValue = variableDefinition.get(0).node.init.value;
+      return varValue;
+    } else if (argument.type === 'MemberExpression') {
+      // for each object selector, try to find its associated definition and the string value,
+      // e.g. if we have assert.dom(SELECTORS.NAME), look for const SELECTORS = { NAME: '[data-test-foo]' } }
+      if (!argument.object) {
+        return;
+      }
+
+      // this should be the name for the object selector, e.g. 'SELECTORS'
+      const objectIdentifierName =
+        argument.object.name || (argument.object.object && argument.object.object.name);
+      // this should be the object property key, e.g. 'NAME'
+      const keyName = argument.property && argument.property.name;
+
+      let objectExpressions = root
+        .findVariableDeclarators(objectIdentifierName)
+        .find(j.ObjectExpression);
+      // go one level deeper if the node we're currently looking at is still a MemberExpression
+      // this accounts for something like SELECTORS.AT.NAME
+      if (argument.object.type === 'MemberExpression') {
+        objectExpressions = objectExpressions.find(j.ObjectExpression);
+      }
+      const keyPaths = objectExpressions.find(j.ObjectProperty, {
+        key: {
+          name: keyName,
+        },
+      });
+      if (keyPaths.length) {
+        const { node } = keyPaths.get(0);
+        const value = node.value && node.value.value;
+        if (value) {
+          return value;
+        }
+      }
+    }
+  }
+
   root
     .find(j.CallExpression, hasAssertDomOrTestHelper)
     .filter((p) => {
       return p.value.arguments.find((arg) => arg.type !== 'Literal');
     })
     .forEach((p) => {
-      if (p.value.arguments[0].type === 'Identifier') {
-        const constName = p.value.arguments[0].name;
-        const variableDefinition = root.find(j.VariableDeclarator, {
-          type: 'VariableDeclarator',
-          id: { type: 'Identifier', name: constName },
-        });
-        const varValue = variableDefinition.get(0).node.init.value;
-        p.value.arguments[0] = j.stringLiteral(varValue);
-      } else if (p.value.arguments[0].type === 'MemberExpression') {
-        // for each object selector, try to find its associated definition and the string value,
-        // e.g. if we have assert.dom(SELECTORS.NAME), look for const SELECTORS = { NAME: '[data-test-foo]' } }
-        const result = p.value.arguments[0];
-        if (!result.object) {
-          return;
-        }
+      // Handles the case when the argument passed into a qunit function is a template literal.
+      if (p.value.arguments[0].type === 'TemplateLiteral') {
+        const templateArgumentMap = p.value.arguments[0].expressions
+          .map((templateArg) => {
+            return resolveArgument(templateArg);
+          })
+          .filter((resolvedArg) => !!resolvedArg);
 
-        // this should be the name for the object selector, e.g. 'SELECTORS'
-        const objectIdentifierName =
-          result.object.name || (result.object.object && result.object.object.name);
-        // this should be the object property key, e.g. 'NAME'
-        const keyName = result.property && result.property.name;
+        // This check ensures that we don't substitute a template literal that we
+        // don't have the full resolution to. (var was probably imported from a consts file)
+        if (p.value.arguments[0].expressions.length === templateArgumentMap.length) {
+          const resolvedTemplateString = p.value.arguments[0].quasis.reduce(
+            (red, templateElement) => {
+              const [literal, ...rest] = red.rest;
+              red.value = red.value + templateElement.value.raw + (literal || '');
+              return { value: red.value, rest: rest };
+            },
+            { value: '', rest: templateArgumentMap }
+          );
 
-        let objectExpressions = root
-          .findVariableDeclarators(objectIdentifierName)
-          .find(j.ObjectExpression);
-        // go one level deeper if the node we're currently looking at is still a MemberExpression
-        // this accounts for something like SELECTORS.AT.NAME
-        if (result.object.type === 'MemberExpression') {
-          objectExpressions = objectExpressions.find(j.ObjectExpression);
+          p.value.arguments[0] = j.stringLiteral(resolvedTemplateString.value);
         }
-        const keyPaths = objectExpressions.find(j.ObjectProperty, {
-          key: {
-            name: keyName,
-          },
-        });
-        if (keyPaths.length) {
-          const { node } = keyPaths.get(0);
-          const value = node.value && node.value.value;
-          if (value) {
-            p.value.arguments[0] = j.stringLiteral(value);
-          }
+      } else {
+        var resolvedArg = resolveArgument(p.value.arguments[0]);
+        if (resolvedArg) {
+          p.value.arguments[0] = j.stringLiteral(resolvedArg);
         }
       }
     });


### PR DESCRIPTION
## Summary
Resolves constants used as selectors, and replaces arguments within template literals. Does not try and resolve template literals unless all variable references can be found.

```js
const NESTED_SELECTORS = { WITH: { BUTTON: '[data-test-button]' } };
const constantSelector = '[data-test-selector]'

test('test', async function(assert) {
    assert.expect(2);
    assert.dom(constantSelector).exists();
    // resolves to `assert.dom( '[data-test-selector]').exists();`
    assert.ok(find(`[data-test-nested] ${NESTED_SELECTORS.WITH.BUTTON} [data-test-nested] ${constantSelector}`));
    // resolves to `assert.ok(find('[data-test-nested] [data-test-button] [data-test-nested] [data-test-selector]'));`
});
```

## Testing
new snapshot tests added. 